### PR TITLE
Restore when paket.lock exists and do not require dummy.sln

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,8 +19,8 @@ echo "-----> Downloading mono to ${CACHE_DIR}/$STACK/vendor"
 if [ ! -d ${CACHE_DIR}/$STACK/vendor/mono ]; then
     mkdir -p ${CACHE_DIR}/$STACK/vendor
     curl -L $MONO3_VM_BINARY -s | tar zxf - -C ${CACHE_DIR}/$STACK/vendor
-    curl $NUGET_BINARY -L -o "${CACHE_DIR}/$STACK/vendor/mono/bin/nuget.exe" 
-    curl $PAKET_BINARY -L -o "${CACHE_DIR}/$STACK/vendor/mono/bin/paket.exe" 
+    curl $NUGET_BINARY -L -o "${CACHE_DIR}/$STACK/vendor/mono/bin/nuget.exe"
+    curl $PAKET_BINARY -L -o "${CACHE_DIR}/$STACK/vendor/mono/bin/paket.exe"
 fi
 
 mkdir -p ${BUILD_DIR}/vendor
@@ -44,25 +44,26 @@ echo "-----> Importing trusted root certificates"
 mono $MOZROOT --sync --import
 cd ${BUILD_DIR}
 
-if [ -f paket.dependencies ]; then
+if [ -f paket.lock ]; then
+  echo "-----> paket.lock found, restoring packages with paket"
+  mono /app/mono/bin/paket.exe restore
+elif [ -f paket.dependencies ]; then
   echo "-----> paket.dependencies found, installing packages with paket"
   mono /app/mono/bin/paket.exe install
 fi
 
-if [ -f packages.config -o -f */packages.config ]; then 
-   echo "-----> packages.config found, installing dependencies with nuget" 
-   find  -name packages.config | xargs mono $NUGET install -o packages 
-fi 
+if [ -f packages.config -o -f */packages.config ]; then
+   echo "-----> packages.config found, installing dependencies with nuget"
+   find  -name packages.config | xargs mono $NUGET install -o packages
+fi
 
 if [ -f app.fsx ]; then
   echo "-----> Compiling app.fsx"
   mono /app/mono/lib/mono/4.5/fsc.exe app.fsx
 elif [ -f *.sln ]; then
-   echo "-----> Compiling application" 
-   mono $XBUILD 
+   echo "-----> Compiling application"
+   mono $XBUILD
 fi
 
-mkdir -p ${BUILD_DIR}/.profile.d 
-cp -n ${LP_DIR}/.profile.d/* ${BUILD_DIR}/.profile.d/ 
-
-
+mkdir -p ${BUILD_DIR}/.profile.d
+cp -n ${LP_DIR}/.profile.d/* ${BUILD_DIR}/.profile.d/

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ -f $1/*.sln ]; then
-    echo "MonoFramework"
+if [ -f $1/*.sln ] || [ -f $1/app.fsx ]; then
+    echo "SuaveFramework"
     exit 0
 else
     exit 1


### PR DESCRIPTION
Sorry for an ugly diff, it seems that the Atom editor does something weird with whitespace :-(

This is doing just two changes:
- in `detect`, check either for `*.sln` or `app.fsx` (so you do not need `dummy.sln`)
- in `compile` run `paket restore` when there is `paket.lock` (this is better because it uses the same version that you're using locally - `paket install` can do unexpected version updates)
