### PR TITLE
Mono users on Linux no longer need to run mozroots to get SSL working

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ export PATH="/app/mono/bin:$PATH"
 export LD_LIBRARY_PATH="/app/mono/lib:$LD_LIBRARY_PATH"
 echo "-----> Importing trusted root certificates"
 cert-sync /etc/ssl/certs/ca-certificates.crt
-cp -r ~/.config ${BUILD_DIR}/.
+#cp -r ~/.config ${BUILD_DIR}/.
 cd ${BUILD_DIR}
 
 if [ -f paket.lock ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,6 @@ echo "-----> Setting envvars"
 export PATH="/app/mono/bin:$PATH"
 export LD_LIBRARY_PATH="/app/mono/lib:$LD_LIBRARY_PATH"
 echo "-----> Importing trusted root certificates"
-#mono $MOZROOT --sync --import
 cert-sync /etc/ssl/certs/ca-certificates.crt
 cp -r ~/.config ${BUILD_DIR}/.
 cd ${BUILD_DIR}

--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ export PATH="/app/mono/bin:$PATH"
 export LD_LIBRARY_PATH="/app/mono/lib:$LD_LIBRARY_PATH"
 echo "-----> Importing trusted root certificates"
 cert-sync /etc/ssl/certs/ca-certificates.crt
-#cp -r ~/.config ${BUILD_DIR}/.
+cp -r ~/.config ${BUILD_DIR}/.
 cd ${BUILD_DIR}
 
 if [ -f paket.lock ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,8 @@ echo "-----> Setting envvars"
 export PATH="/app/mono/bin:$PATH"
 export LD_LIBRARY_PATH="/app/mono/lib:$LD_LIBRARY_PATH"
 echo "-----> Importing trusted root certificates"
-mono $MOZROOT --sync --import
+#mono $MOZROOT --sync --import
+cert-sync /etc/ssl/certs/ca-certificates.crt
 cp -r ~/.config ${BUILD_DIR}/.
 cd ${BUILD_DIR}
 


### PR DESCRIPTION
I have try this script with an error about certificates I found that http://www.mono-project.com/docs/about-mono/releases/3.12.0/#cert-sync

Mono users on Linux no longer need to run mozroots to get SSL working. A new command, cert-sync, has been added to this release, which synchronizes the Mono SSL certificate store against your OS certificate store – and this tool has been integrated into the packaging system for all mono-project.com packages, so it is automatically used when you install Mono via our packages.

I have this output on Heroku :

```
Linux Cert Store Sync - version 3.12.1.0
Synchronize local certs with certs from local Linux trust store.
Copyright 2002, 2003 Motus Technologies. Copyright 2004-2008 Novell. BSD licensed.

I already trust 0, your new list has 173
Warning: Could not import {0}
...
Warning: Could not import {0}
173 new root certificates were added to your trust store.
Import process completed.
```

So that seems to work but with a lot of warnings.
After that I have another error that I'm not able to fix actually :
`cp: cannot stat ‘/app/.config’: No such file or directory`
I have try to remove cp -r ~/.config ${BUILD_DIR}/. so there are no errors but I have build looping again and again.

Hope that help,
Emmanuel
