### PR TITLE
Adds Support for Heroku ENV_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ set -e
 
 MONO3_VM_BINARY="https://github.com/SuaveIO/mono-builder/releases/download/0.0.9/mono-4.4.2.11.tar.gz"
 NUGET_BINARY="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
-PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/3.13.3/paket.exe"
+PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/5.120.0/paket.exe"
 
 NUGET="${BUILD_DIR}/vendor/mono/bin/nuget.exe"
 MOZROOT="${BUILD_DIR}/vendor/mono/lib/mono/4.5/mozroots.exe"

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ set -e
 
 MONO3_VM_BINARY="https://github.com/SuaveIO/mono-builder/releases/download/0.0.9/mono-4.4.2.11.tar.gz"
 NUGET_BINARY="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
-PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/3.13.3/paket.exe"
+PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/5.120.0/paket.exe"
 
 NUGET="${BUILD_DIR}/vendor/mono/bin/nuget.exe"
 MOZROOT="${BUILD_DIR}/vendor/mono/lib/mono/4.5/mozroots.exe"

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/compile <build-dir> <cache-dir>
+# bin/compile <build-dir> <cache-dir> <env-dir>
 
 BUILD_DIR=$1
 CACHE_DIR=$2
@@ -29,7 +29,8 @@ export_env_dir() {
     done
   fi
 }
-export_env_dir
+
+export_env_dir $ENV_DIR
 
 echo "-----> Downloading mono to ${CACHE_DIR}/$STACK/vendor"
 if [ ! -d ${CACHE_DIR}/$STACK/vendor/mono ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ set -e
 
 MONO3_VM_BINARY="https://github.com/SuaveIO/mono-builder/releases/download/0.0.9/mono-4.4.2.11.tar.gz"
 NUGET_BINARY="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
-PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/5.120.0/paket.exe"
+PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/3.13.3/paket.exe"
 
 NUGET="${BUILD_DIR}/vendor/mono/bin/nuget.exe"
 MOZROOT="${BUILD_DIR}/vendor/mono/lib/mono/4.5/mozroots.exe"

--- a/bin/compile
+++ b/bin/compile
@@ -3,6 +3,7 @@
 
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 LP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 # fail fast
@@ -15,6 +16,20 @@ PAKET_BINARY="https://github.com/fsprojects/Paket/releases/download/5.120.0/pake
 NUGET="${BUILD_DIR}/vendor/mono/bin/nuget.exe"
 MOZROOT="${BUILD_DIR}/vendor/mono/lib/mono/4.5/mozroots.exe"
 XBUILD="${BUILD_DIR}/vendor/mono/lib/mono/4.5/xbuild.exe"
+
+export_env_dir() {
+  env_dir=$1
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}
+export_env_dir
 
 echo "-----> Downloading mono to ${CACHE_DIR}/$STACK/vendor"
 if [ ! -d ${CACHE_DIR}/$STACK/vendor/mono ]; then


### PR DESCRIPTION
This pull request adds support for Heroku's [ENV_DIR](https://devcenter.heroku.com/changelog-items/416) in the mono build pack. And also adds script function make project config values available as environment variables as mentioned [in their documentation](https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary).

This will support use cases like running a schema migration via FAKE Script which gets the database connection string from the Environment variable. 

This also updates paket's version to `5.120.0`. 